### PR TITLE
Enable metrics from docker daemon

### DIFF
--- a/parts/configure-swarmmode-cluster.sh
+++ b/parts/configure-swarmmode-cluster.sh
@@ -179,7 +179,7 @@ updateDockerDaemonOptions()
     # also have it bind to the unix socket at /var/run/docker.sock
     sudo bash -c 'echo "[Service]
     ExecStart=
-    ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
+    ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --experimental --metrics-addr=0.0.0.0:2393
   " > /etc/systemd/system/docker.service.d/override.conf'
 }
 time updateDockerDaemonOptions


### PR DESCRIPTION
Issue ekstep/sunbird-devops#204 feat: Enable metrics from docker daemon to alert when a docker node goes down